### PR TITLE
Altered webworker-child to permit the global worker object to be passed by reference.

### DIFF
--- a/examples/trivial/master.js
+++ b/examples/trivial/master.js
@@ -1,0 +1,8 @@
+var Worker = require("webworker").Worker;
+var worker = new Worker(__dirname + "/worker.js");
+worker.onmessage = function (message) {
+    console.log(message.data);
+    worker.terminate();
+};
+worker.postMessage("Hello, World!");
+

--- a/examples/trivial/worker.js
+++ b/examples/trivial/worker.js
@@ -1,0 +1,6 @@
+var worker = this;
+worker.onmessage = function (message) {
+    // echo
+    worker.postMessage(message.data);
+}
+

--- a/lib/webworker-child.js
+++ b/lib/webworker-child.js
@@ -125,7 +125,7 @@ ws.addListener('open', function() {
     process.addListener('uncaughtException', exceptionHandler);
 
     // Execute the worker
-    scriptObj.runInNewContext(workerCtx);
+    scriptObj.runInThisContext();
 });
 
 // Construt the Script object to host the worker's code
@@ -145,7 +145,7 @@ default:
 }
 
 // Set up the context for the worker instance
-var workerCtx = {};
+var workerCtx = global;
 
 // Context elements required for node.js
 //


### PR DESCRIPTION
For some reason, using runInNewContext occludes the worker object, which it would be handy to be able to pass to an API for standard message passing setup.

I've also added a trivial example.

I would like to see the worker run as a module so relative module identifiers can be used inside the worker, relative to the worker file instead of the webworker-child module. This might require node to expose more of its module system primitives though.
