### PR TITLE
Work around issue with path.join ignoring numeric arguments.

### DIFF
--- a/lib/webworker.js
+++ b/lib/webworker.js
@@ -90,7 +90,7 @@ var Worker = function(src, opts) {
     var msgQueue = [];
 
     // The path to our socket
-    var sockPath = path.join(SOCK_DIR_PATH, numWorkersCreated++);
+    var sockPath = path.join(SOCK_DIR_PATH, '' + numWorkersCreated++);
 
     // Server instance for our communication socket with the child process
     //


### PR DESCRIPTION
This is just a small change to get the path.join call in webworker.js working as it should.  I've added `'' +` to the numeric property numWorkersCreated so the path is correctly formatted.
