### PR TITLE
Fix for problem when passing additional args to new Worker

### DIFF
--- a/lib/webworker-child.js
+++ b/lib/webworker-child.js
@@ -108,6 +108,8 @@ if (process.argv.length < 4) {
     throw new Error('usage: node worker.js <sock> <script>');
 }
 
+var additionalArgs = process.argv.splice(4, process.argv.length);
+
 var sockPath = process.argv[2];
 var scriptLoc = new wwutil.WorkerLocation(process.argv[3]);
 
@@ -160,6 +162,7 @@ workerCtx.setTimeout = setTimeout;
 workerCtx.clearTimeout = clearTimeout;
 workerCtx.setInterval = setInterval;
 workerCtx.clearInterval = clearInterval;
+workerCtx.additionalArgs = additionalArgs;
 
 // Context elements required by the WebWorkers API spec
 workerCtx.postMessage = function(msg, fd) {

--- a/lib/webworker.js
+++ b/lib/webworker.js
@@ -130,11 +130,11 @@ var Worker = function(src, opts) {
             ];
             if (opts.args) {
                 if (Array.isArray(opts.args)) {
-                    for (var ii = opts.args.length; ii >= 0; ii--) {
-                        args.splice(0, 0, opts.args[ii]);
+                    for (var i = 0; i < opts.args.length; i++) {
+                        args.push(opts.args[i]);
                     }
                 } else {
-                    args.splice(0, 0, opts.args.toString());
+                    args.push(opts.args.toString());
                 }
             }
 


### PR DESCRIPTION
I've run into an issue when doing trying to create a worker with additional parameters:

 var w = new Worker('/Users/me/webworkers/foo.js', {args: ["some","args"]});

With the current codebase, the args would be added before the rest of the arguments, causing multiple problems. I fixed it by pushing the new args after the current arguments. I also added a convenience method to access it from the child elements.

Let me know what you think
