### PR TITLE
replaced exports.Workers with module.exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See the design document
 #### Master source
 
     var sys = require('sys');
-    var Worker = require('webworker').Worker;
+    var Worker = require('webworker');
     
     var w = new Worker('foo.js');
     

--- a/examples/prefork/master.js
+++ b/examples/prefork/master.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var netBindings = process.binding('net');
-var Worker = require('../lib/webworker').Worker;
+var Worker = require('../lib/webworker');
 
 var fd = netBindings.socket('tcp4');
 netBindings.bind(fd, 80);

--- a/lib/webworker.js
+++ b/lib/webworker.js
@@ -298,7 +298,7 @@ var Worker = function(src, opts) {
     // Fire it up
     start();
 };
-exports.Worker = Worker;
+module.exports = Worker;
 
 // Perform any one-time initialization
 fs.mkdirSync(SOCK_DIR_PATH, 0700);

--- a/test/test-error.js
+++ b/test/test-error.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert');
 var path = require('path');
-var Worker = require('../lib/webworker').Worker;
+var Worker = require('../lib/webworker');
 
 var w = new Worker(path.join(__dirname, 'workers', 'error.js'));
 

--- a/test/test-fd.js
+++ b/test/test-fd.js
@@ -5,7 +5,7 @@ var net = require('net');
 var netBinding = process.binding('net');
 var path = require('path');
 var sys = require('sys');
-var Worker = require('../lib/webworker').Worker;
+var Worker = require('../lib/webworker');
 
 var w = new Worker(path.join(__dirname, 'workers', 'fd.js'));
 

--- a/test/test-simple.js
+++ b/test/test-simple.js
@@ -4,7 +4,7 @@
 var assert = require('assert');
 var path = require('path');
 var sys = require('sys');
-var Worker = require('../lib/webworker').Worker;
+var Worker = require('../lib/webworker');
 
 var receivedMsg = false;
 var receivedExit = false;


### PR DESCRIPTION
so whe can require a worker in thy way:

``` javascript
var Worker = require('webworker');
```

i think this is much cleaner / smarter for monoclass files
