### PR TITLE
CoffeeScript support for node-webworkers

### DIFF
--- a/lib/webworker-child.js
+++ b/lib/webworker-child.js
@@ -28,6 +28,8 @@ try {
     );
 }
 
+
+
 var writeError = process.binding('stdio').writeError;
 
 // Catch exceptions
@@ -132,14 +134,25 @@ ws.addListener('open', function() {
 var scriptObj = undefined;
 switch (scriptLoc.protocol) {
 case 'file':
+
+
+    scriptSrc = fs.readFileSync(scriptLoc.pathname)
+
+    // support coffeescript precompilation, if needed.
+    try {
+        if (scriptLoc.pathname.match(/.coffee/)) {
+            scriptSrc = require('coffee-script').compile(scriptSrc.toString())
+        }
+    } catch (e) {}
+
     scriptObj = new script.Script(
-        fs.readFileSync(scriptLoc.pathname),
+        scriptSrc,
         scriptLoc.href
     );
     break;
 
 default:
-    writeError('Cannot load script from unknown protocol \'' + 
+    writeError('Cannot load script from unknown protocol \'' +
         scriptLoc.protocol);
     process.exit(1);
 }


### PR DESCRIPTION
I've added a very simple pre-compilation step to the webworker-child.js file. This change does not require you to have coffeescript installed or use it at all, but if you have it installed and are using it, it will precompile the files for you and act normally.

Enjoy!
