### PR TITLE
Making node-webworker node v0.5.0 compatible with backwards compatibility

### DIFF
--- a/lib/webworker-child.js
+++ b/lib/webworker-child.js
@@ -132,7 +132,8 @@ ws.addListener('open', function() {
 var scriptObj = undefined;
 switch (scriptLoc.protocol) {
 case 'file':
-    scriptObj = new script.NodeScript(
+	var script_function = script.Script || script.NodeScript;
+    scriptObj = new script_function(
         fs.readFileSync(scriptLoc.pathname),
         scriptLoc.href
     );

--- a/lib/webworker-child.js
+++ b/lib/webworker-child.js
@@ -132,7 +132,7 @@ ws.addListener('open', function() {
 var scriptObj = undefined;
 switch (scriptLoc.protocol) {
 case 'file':
-    scriptObj = new script.Script(
+    scriptObj = new script.NodeScript(
         fs.readFileSync(scriptLoc.pathname),
         scriptLoc.href
     );


### PR DESCRIPTION
Changing webworker-child.js to use `script.NodeScript` over `script.Script` when it exists.
