### PR TITLE
"Buffer is not defined" in child worker

### DIFF
--- a/lib/webworker-child.js
+++ b/lib/webworker-child.js
@@ -160,6 +160,7 @@ workerCtx.setTimeout = setTimeout;
 workerCtx.clearTimeout = clearTimeout;
 workerCtx.setInterval = setInterval;
 workerCtx.clearInterval = clearInterval;
+workerCtx.Buffer = Buffer;
 
 // Context elements required by the WebWorkers API spec
 workerCtx.postMessage = function(msg, fd) {

--- a/test/test-globals.js
+++ b/test/test-globals.js
@@ -1,0 +1,29 @@
+// Verify that the worker has all global variables.
+
+var assert = require('assert');
+var path = require('path');
+var sys = require('sys');
+var Worker = require('../lib/webworker');
+
+var receivedMsg = false;
+
+var w = new Worker(path.join(__dirname, 'workers', 'globals.js'));
+
+w.onmessage = function(e) {
+    assert.ok('data' in e);
+    assert.equal(e.data.result, 'ok');
+
+    receivedMsg = true;
+
+    w.terminate();
+};
+
+w.onerror = function(e) {
+    console.dir(e);
+
+    w.terminate();
+};
+
+process.addListener('exit', function() {
+    assert.equal(receivedMsg, true);
+});

--- a/test/workers/globals.js
+++ b/test/workers/globals.js
@@ -1,0 +1,19 @@
+var assert = require('assert');
+
+assert.equal(typeof global, 'object');
+assert.equal(typeof process, 'object');
+assert.equal(typeof console, 'object');
+assert.equal(typeof Buffer, 'function');
+assert.equal(typeof require, 'function');
+assert.equal(typeof require.resolve, 'function');
+assert.equal(typeof require.cache, 'object');
+assert.equal(typeof __filename, 'string');
+assert.equal(typeof __dirname, 'string');
+assert.equal(typeof setTimeout, 'function');
+assert.equal(typeof clearTimeout, 'function');
+assert.equal(typeof setInterval, 'function');
+assert.equal(typeof clearInterval, 'function');
+
+assert.equal(typeof postMessage, 'function');
+
+postMessage({ result: 'ok' });


### PR DESCRIPTION
Worker script which uses Buffer causes "Buffer is not defined" error.
This patch fixes it by passing Buffer variable to worker context.
